### PR TITLE
Load compiled Core Data model when creating persistence container

### DIFF
--- a/Sources/Persistence/PersistenceController.swift
+++ b/Sources/Persistence/PersistenceController.swift
@@ -11,7 +11,9 @@ public final class PersistenceController {
     public let container: NSPersistentCloudKitContainer
 
     private init(inMemory: Bool = false) {
-        container = NSPersistentCloudKitContainer(name: "HomeCare")
+        let modelURL = Bundle.module.url(forResource: "HomeCare", withExtension: "momd")!
+        let model = NSManagedObjectModel(contentsOf: modelURL)!
+        container = NSPersistentCloudKitContainer(name: "HomeCare", managedObjectModel: model)
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
         }


### PR DESCRIPTION
## Summary
- Build NSPersistentCloudKitContainer using the compiled HomeCare model from Bundle.module

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689cb125959c8327ac1835182d8fbf1a