### PR TITLE
Enable adding new homes from the homes list

### DIFF
--- a/Sources/Features/Homes/EditHomeView.swift
+++ b/Sources/Features/Homes/EditHomeView.swift
@@ -7,10 +7,13 @@ public struct EditHomeView: View {
     @State private var address: String
     @State private var notes: String
 
-    public init(home: HomeEntity? = nil) {
+    private var onSave: (HomeEntity) -> Void
+
+    public init(home: HomeEntity? = nil, onSave: @escaping (HomeEntity) -> Void = { _ in }) {
         _name = State(initialValue: home?.name ?? "")
         _address = State(initialValue: home?.address ?? "")
         _notes = State(initialValue: home?.notes ?? "")
+        self.onSave = onSave
     }
 
     public var body: some View {
@@ -24,7 +27,12 @@ public struct EditHomeView: View {
         .navigationTitle("Home")
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {}
+                Button("Save") {
+                    let newHome = HomeEntity(name: name,
+                                            address: address.isEmpty ? nil : address,
+                                            notes: notes.isEmpty ? nil : notes)
+                    onSave(newHome)
+                }
             }
         }
     }

--- a/Sources/Features/Homes/HomesListView.swift
+++ b/Sources/Features/Homes/HomesListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct HomesListView: View {
     public init() {}
     @State private var homes: [HomeEntity] = []
+    @State private var isPresentingNewHome = false
 
     public var body: some View {
         NavigationStack {
@@ -16,7 +17,15 @@ public struct HomesListView: View {
             .navigationTitle("Homes")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {}) { Image(systemName: "plus") }
+                    Button(action: { isPresentingNewHome = true }) { Image(systemName: "plus") }
+                }
+            }
+            .sheet(isPresented: $isPresentingNewHome) {
+                NavigationStack {
+                    EditHomeView { home in
+                        homes.append(home)
+                        isPresentingNewHome = false
+                    }
                 }
             }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)


### PR DESCRIPTION
## Summary
- Show an add-home sheet when tapping plus in HomesListView
- Save home details via EditHomeView callback

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689cf72428288327955c59840a7b44d8