### PR TITLE
Connect add buttons to creation forms

### DIFF
--- a/Sources/Features/Assets/AssetsListView.swift
+++ b/Sources/Features/Assets/AssetsListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct AssetsListView: View {
     public let home: HomeEntity
     @State private var assets: [AssetEntity] = []
+    @State private var isPresentingNewAsset = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -17,7 +18,16 @@ public struct AssetsListView: View {
         .navigationTitle("Assets")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) { Image(systemName: "plus") }
+                Button {
+                    isPresentingNewAsset = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $isPresentingNewAsset) {
+            NavigationStack {
+                EditAssetView()
             }
         }
     }

--- a/Sources/Features/Homes/HomesListView.swift
+++ b/Sources/Features/Homes/HomesListView.swift
@@ -17,7 +17,11 @@ public struct HomesListView: View {
             .navigationTitle("Homes")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { isPresentingNewHome = true }) { Image(systemName: "plus") }
+                    Button {
+                        isPresentingNewHome = true
+                    } label: {
+                        Image(systemName: "plus")
+                    }
                 }
             }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)

--- a/Sources/Features/Tasks/TasksListView.swift
+++ b/Sources/Features/Tasks/TasksListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct TasksListView: View {
     public let home: HomeEntity
     @State private var tasks: [TaskEntity] = []
+    @State private var isPresentingNewTask = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -15,7 +16,16 @@ public struct TasksListView: View {
         .navigationTitle("Tasks")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) { Image(systemName: "plus") }
+                Button {
+                    isPresentingNewTask = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $isPresentingNewTask) {
+            NavigationStack {
+                EditTaskView()
             }
         }
     }


### PR DESCRIPTION
## Summary
- open new home creation view from HomesListView's add button
- show task and asset creation forms from their list toolbars

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689d08727a88832789d1cef8bafe8120