### PR TITLE
Enable saving new homes from EditHomeView

### DIFF
--- a/HomeUpkeepPal/Features/Homes/EditHomeView.swift
+++ b/HomeUpkeepPal/Features/Homes/EditHomeView.swift
@@ -3,11 +3,15 @@ import SwiftUI
 
 /// Form for creating or editing a home.
 public struct EditHomeView: View {
+    @Environment(\.dismiss) private var dismiss
     @State private var name: String
     @State private var address: String
     @State private var notes: String
 
-    public init(home: HomeEntity? = nil) {
+    private let onSave: (HomeEntity) -> Void
+
+    public init(home: HomeEntity? = nil, onSave: @escaping (HomeEntity) -> Void = { _ in }) {
+        self.onSave = onSave
         _name = State(initialValue: home?.name ?? "")
         _address = State(initialValue: home?.address ?? "")
         _notes = State(initialValue: home?.notes ?? "")
@@ -24,7 +28,15 @@ public struct EditHomeView: View {
         .navigationTitle("Home")
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {}
+                Button("Save") {
+                    let home = HomeEntity(
+                        name: name,
+                        address: address.isEmpty ? nil : address,
+                        notes: notes.isEmpty ? nil : notes
+                    )
+                    onSave(home)
+                    dismiss()
+                }
             }
         }
     }

--- a/HomeUpkeepPal/Features/Homes/HomesListView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomesListView.swift
@@ -23,7 +23,9 @@ public struct HomesListView: View {
                 }
             }
             .navigationDestination(isPresented: $showEditHome) {
-                EditHomeView() 
+                EditHomeView { newHome in
+                    homes.append(newHome)
+                }
             }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)
         }


### PR DESCRIPTION
## Summary
- Save new homes via `EditHomeView` and dismiss the view
- Append saved homes to the list in `HomesListView`

## Testing
- `swift test` *(fails: 'home-upkeep-pal': invalid custom path 'Sources' for target 'HomeCare')*

------
https://chatgpt.com/codex/tasks/task_b_689d3e305d948327a553cdc21b11be09