### PR TITLE
Link dashboard tabs to asset and task lists with add buttons

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct AssetsListView: View {
     public let home: HomeEntity
     @State private var assets: [AssetEntity] = []
+    @State private var showEditAsset = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -17,8 +18,13 @@ public struct AssetsListView: View {
         .navigationTitle("Assets")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) { Image(systemName: "plus") }
+                Button(action: { showEditAsset = true }) {
+                    Image(systemName: "plus")
+                }
             }
+        }
+        .navigationDestination(isPresented: $showEditAsset) {
+            EditAssetView()
         }
     }
 }

--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -8,12 +8,16 @@ public struct HomeDashboardView: View {
 
     public var body: some View {
         TabView {
-            TasksListView(home: home)
-                .tabItem { Label("Tasks", systemImage: "checklist") }
-            AssetsListView(home: home)
-                .tabItem { Label("Assets", systemImage: "cube") }
+            NavigationStack {
+                TasksListView(home: home)
+            }
+            .tabItem { Label("Tasks", systemImage: "checklist") }
+
+            NavigationStack {
+                AssetsListView(home: home)
+            }
+            .tabItem { Label("Assets", systemImage: "cube") }
         }
-        .navigationTitle(home.name)
     }
 }
 #endif

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 public struct TasksListView: View {
     public let home: HomeEntity
     @State private var tasks: [TaskEntity] = []
+    @State private var showEditTask = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -15,8 +16,13 @@ public struct TasksListView: View {
         .navigationTitle("Tasks")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {}) { Image(systemName: "plus") }
+                Button(action: { showEditTask = true }) {
+                    Image(systemName: "plus")
+                }
             }
+        }
+        .navigationDestination(isPresented: $showEditTask) {
+            EditTaskView()
         }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     targets: [
         .target(
             name: "HomeCare",
-            path: "Sources",
+            path: "HomeUpkeepPal",
             resources: [
                 .process("Persistence/Model")
             ]
@@ -20,7 +20,7 @@ let package = Package(
         .testTarget(
             name: "HomeCareTests",
             dependencies: ["HomeCare"],
-            path: "Tests/HomeCareTests"
+            path: "HomeUpkeepPalTests"
         )
     ]
 )


### PR DESCRIPTION
## Summary
- Wrap dashboard tabs in NavigationStack so Tasks and Assets views show correctly
- Add navigation destinations for creating new tasks and assets
- Attach plus buttons in list views to open edit forms
- Point Swift package target and test paths to project directories

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_689d40b81ab0832790890b11ede1c642