### PR TITLE
Fix empty home dashboard views and add creation buttons

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -15,6 +15,7 @@ public struct AssetsListView: View {
                 Text(asset.name)
             }
         }
+        .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
         .navigationTitle("Assets")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {

--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -8,15 +8,11 @@ public struct HomeDashboardView: View {
 
     public var body: some View {
         TabView {
-            NavigationStack {
-                TasksListView(home: home)
-            }
-            .tabItem { Label("Tasks", systemImage: "checklist") }
+            TasksListView(home: home)
+                .tabItem { Label("Tasks", systemImage: "checklist") }
 
-            NavigationStack {
-                AssetsListView(home: home)
-            }
-            .tabItem { Label("Assets", systemImage: "cube") }
+            AssetsListView(home: home)
+                .tabItem { Label("Assets", systemImage: "cube") }
         }
     }
 }

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -13,6 +13,7 @@ public struct TasksListView: View {
         List(tasks) { task in
             TaskRowView(task: task)
         }
+        .overlay(tasks.isEmpty ? EmptyStateView(message: "No tasks yet") : nil)
         .navigationTitle("Tasks")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## Summary
- show Tasks and Assets views directly in HomeDashboard without nested navigation stacks
- display empty-state messaging when no tasks or assets exist

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_689e3d3efa3883279c38751e95a247e7