### PR TITLE
Fix empty home dashboard views and add creation buttons

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 public struct AssetsListView: View {
     public let home: HomeEntity
     @State private var assets: [AssetEntity] = []
-    @State private var showEditAsset = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -15,17 +14,7 @@ public struct AssetsListView: View {
                 Text(asset.name)
             }
         }
-        .navigationTitle("Assets")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: { showEditAsset = true }) {
-                    Image(systemName: "plus")
-                }
-            }
-        }
-        .navigationDestination(isPresented: $showEditAsset) {
-            EditAssetView()
-        }
+        .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
     }
 }
 #endif

--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -4,19 +4,45 @@ import SwiftUI
 /// Dashboard for a specific home showing upcoming tasks and navigation to assets and tasks.
 public struct HomeDashboardView: View {
     public let home: HomeEntity
+    @State private var selection: Tab = .tasks
+    @State private var showEditTask = false
+    @State private var showEditAsset = false
+
+    enum Tab {
+        case tasks
+        case assets
+    }
+
     public init(home: HomeEntity) { self.home = home }
 
     public var body: some View {
-        TabView {
-            NavigationStack {
-                TasksListView(home: home)
-            }
-            .tabItem { Label("Tasks", systemImage: "checklist") }
+        TabView(selection: $selection) {
+            TasksListView(home: home)
+                .tabItem { Label("Tasks", systemImage: "checklist") }
+                .tag(Tab.tasks)
 
-            NavigationStack {
-                AssetsListView(home: home)
+            AssetsListView(home: home)
+                .tabItem { Label("Assets", systemImage: "cube") }
+                .tag(Tab.assets)
+        }
+        .navigationTitle(selection == .tasks ? "Tasks" : "Assets")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    switch selection {
+                    case .tasks: showEditTask = true
+                    case .assets: showEditAsset = true
+                    }
+                }) {
+                    Image(systemName: "plus")
+                }
             }
-            .tabItem { Label("Assets", systemImage: "cube") }
+        }
+        .navigationDestination(isPresented: $showEditTask) {
+            EditTaskView()
+        }
+        .navigationDestination(isPresented: $showEditAsset) {
+            EditAssetView()
         }
     }
 }

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 public struct TasksListView: View {
     public let home: HomeEntity
     @State private var tasks: [TaskEntity] = []
-    @State private var showEditTask = false
 
     public init(home: HomeEntity) { self.home = home }
 
@@ -13,17 +12,7 @@ public struct TasksListView: View {
         List(tasks) { task in
             TaskRowView(task: task)
         }
-        .navigationTitle("Tasks")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: { showEditTask = true }) {
-                    Image(systemName: "plus")
-                }
-            }
-        }
-        .navigationDestination(isPresented: $showEditTask) {
-            EditTaskView()
-        }
+        .overlay(tasks.isEmpty ? EmptyStateView(message: "No tasks yet") : nil)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- centralize navigation title and add a plus button in HomeDashboardView for creating tasks or assets
- keep empty-state overlays for task and asset lists when they are empty

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_689e3d3efa3883279c38751e95a247e7