### PR TITLE
Enable saving assets and tasks with optional asset details

### DIFF
--- a/HomeUpkeepPal/ContentView.swift
+++ b/HomeUpkeepPal/ContentView.swift
@@ -5,6 +5,7 @@
 //  Created by DJ Spiess on 8/13/25.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 struct ContentView: View {
@@ -22,3 +23,4 @@ struct ContentView: View {
 #Preview {
     ContentView()
 }
+#endif

--- a/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
@@ -12,6 +12,8 @@ public struct AssetDetailView: View {
                 Text(asset.name)
                 Text(asset.category.rawValue.capitalized)
                 if let location = asset.location { Text(location) }
+                if let model = asset.model { Text(model) }
+                if let serial = asset.serial { Text(serial) }
             }
             Section("Tasks") {
                 Text("Related tasks appear here")

--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -4,9 +4,12 @@ import SwiftUI
 /// Shows assets in a home.
 public struct AssetsListView: View {
     public let home: HomeEntity
-    @State private var assets: [AssetEntity] = []
+    @Binding private var assets: [AssetEntity]
 
-    public init(home: HomeEntity) { self.home = home }
+    public init(home: HomeEntity, assets: Binding<[AssetEntity]>) {
+        self.home = home
+        _assets = assets
+    }
 
     public var body: some View {
         List(assets) { asset in

--- a/HomeUpkeepPal/Features/Assets/EditAssetView.swift
+++ b/HomeUpkeepPal/Features/Assets/EditAssetView.swift
@@ -3,14 +3,26 @@ import SwiftUI
 
 /// Form to create or edit an asset.
 public struct EditAssetView: View {
+    @Environment(\.dismiss) private var dismiss
     @State private var name: String
     @State private var category: AssetEntity.Category
     @State private var location: String
+    @State private var model: String
+    @State private var serial: String
 
-    public init(asset: AssetEntity? = nil) {
+    private let home: HomeEntity
+    private let onSave: (AssetEntity) -> Void
+
+    public init(home: HomeEntity,
+                asset: AssetEntity? = nil,
+                onSave: @escaping (AssetEntity) -> Void = { _ in }) {
+        self.home = home
+        self.onSave = onSave
         _name = State(initialValue: asset?.name ?? "")
         _category = State(initialValue: asset?.category ?? .other)
         _location = State(initialValue: asset?.location ?? "")
+        _model = State(initialValue: asset?.model ?? "")
+        _serial = State(initialValue: asset?.serial ?? "")
     }
 
     public var body: some View {
@@ -23,12 +35,26 @@ public struct EditAssetView: View {
                     }
                 }
                 TextField("Location", text: $location)
+                TextField("Model", text: $model)
+                TextField("Serial Number", text: $serial)
             }
         }
         .navigationTitle("Asset")
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {}
+                Button("Save") {
+                    let asset = AssetEntity(
+                        homeID: home.id,
+                        name: name,
+                        category: category,
+                        location: location.isEmpty ? nil : location,
+                        model: model.isEmpty ? nil : model,
+                        serial: serial.isEmpty ? nil : serial
+                    )
+                    onSave(asset)
+                    dismiss()
+                }
+                .disabled(name.isEmpty)
             }
         }
     }

--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -7,6 +7,8 @@ public struct HomeDashboardView: View {
     @State private var selection: Tab = .tasks
     @State private var showEditTask = false
     @State private var showEditAsset = false
+    @State private var tasks: [TaskEntity] = []
+    @State private var assets: [AssetEntity] = []
 
     enum Tab {
         case tasks
@@ -17,11 +19,11 @@ public struct HomeDashboardView: View {
 
     public var body: some View {
         TabView(selection: $selection) {
-            TasksListView(home: home)
+            TasksListView(home: home, tasks: $tasks)
                 .tabItem { Label("Tasks", systemImage: "checklist") }
                 .tag(Tab.tasks)
 
-            AssetsListView(home: home)
+            AssetsListView(home: home, assets: $assets)
                 .tabItem { Label("Assets", systemImage: "cube") }
                 .tag(Tab.assets)
         }
@@ -39,10 +41,14 @@ public struct HomeDashboardView: View {
             }
         }
         .navigationDestination(isPresented: $showEditTask) {
-            EditTaskView()
+            EditTaskView(home: home) { task in
+                tasks.append(task)
+            }
         }
         .navigationDestination(isPresented: $showEditAsset) {
-            EditAssetView()
+            EditAssetView(home: home) { asset in
+                assets.append(asset)
+            }
         }
     }
 }

--- a/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
+++ b/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
@@ -3,12 +3,23 @@ import SwiftUI
 
 /// Form to create or edit a task.
 public struct EditTaskView: View {
+    @Environment(\.dismiss) private var dismiss
     @State private var title: String
     @State private var frequencyDays: Int
     @State private var lastDoneAt: Date
     @State private var notes: String
 
-    public init(task: TaskEntity? = nil) {
+    private let home: HomeEntity
+    private let asset: AssetEntity?
+    private let onSave: (TaskEntity) -> Void
+
+    public init(home: HomeEntity,
+                asset: AssetEntity? = nil,
+                task: TaskEntity? = nil,
+                onSave: @escaping (TaskEntity) -> Void = { _ in }) {
+        self.home = home
+        self.asset = asset
+        self.onSave = onSave
         _title = State(initialValue: task?.title ?? "")
         _frequencyDays = State(initialValue: task?.frequencyDays ?? 1)
         _lastDoneAt = State(initialValue: task?.lastDoneAt ?? Date())
@@ -29,7 +40,21 @@ public struct EditTaskView: View {
         .navigationTitle("Task")
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Button("Save") {}
+                Button("Save") {
+                    let nextDue = Calendar.current.date(byAdding: .day, value: frequencyDays, to: lastDoneAt) ?? Date()
+                    let task = TaskEntity(
+                        homeID: home.id,
+                        assetID: asset?.id,
+                        title: title,
+                        notes: notes.isEmpty ? nil : notes,
+                        frequencyDays: frequencyDays,
+                        lastDoneAt: lastDoneAt,
+                        nextDueAt: nextDue
+                    )
+                    onSave(task)
+                    dismiss()
+                }
+                .disabled(title.isEmpty)
             }
         }
     }

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -4,9 +4,12 @@ import SwiftUI
 /// Lists tasks for a home grouped by simple status for MVP.
 public struct TasksListView: View {
     public let home: HomeEntity
-    @State private var tasks: [TaskEntity] = []
+    @Binding private var tasks: [TaskEntity]
 
-    public init(home: HomeEntity) { self.home = home }
+    public init(home: HomeEntity, tasks: Binding<[TaskEntity]>) {
+        self.home = home
+        _tasks = tasks
+    }
 
     public var body: some View {
         List(tasks) { task in

--- a/HomeUpkeepPal/HomeUpkeepPalApp.swift
+++ b/HomeUpkeepPal/HomeUpkeepPalApp.swift
@@ -5,6 +5,7 @@
 //  Created by DJ Spiess on 8/13/25.
 //
 
+#if canImport(SwiftUI)
 import SwiftUI
 
 @main
@@ -15,3 +16,4 @@ struct HomeUpkeepPalApp: App {
         }
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- Wire up save actions in asset and task editors and propagate results to the home dashboard
- Add optional model and serial number fields to assets and display them in asset details
- Wrap SwiftUI entry points in conditional compilation to build in non-SwiftUI environments

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689e4a147c1883279a5f79f1e326a88c