### PR TITLE
Enable editing and task completion

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
@@ -3,8 +3,15 @@ import SwiftUI
 
 /// Detail screen for an asset with related tasks.
 public struct AssetDetailView: View {
-    public let asset: AssetEntity
-    public init(asset: AssetEntity) { self.asset = asset }
+    public let home: HomeEntity
+    private let assetRepository = CoreDataAssetRepository()
+    @State private var asset: AssetEntity
+    @State private var showEdit = false
+
+    public init(home: HomeEntity, asset: AssetEntity) {
+        self.home = home
+        _asset = State(initialValue: asset)
+    }
 
     public var body: some View {
         List {
@@ -36,6 +43,19 @@ public struct AssetDetailView: View {
             }
         }
         .navigationTitle(asset.name)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit") { showEdit = true }
+            }
+        }
+        .navigationDestination(isPresented: $showEdit) {
+            EditAssetView(home: home, asset: asset) { updated in
+                Task {
+                    try? await assetRepository.update(asset: updated)
+                    asset = updated
+                }
+            }
+        }
     }
 }
 #endif

--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -5,6 +5,9 @@ import SwiftUI
 public struct AssetsListView: View {
     public let home: HomeEntity
     @Binding private var assets: [AssetEntity]
+    @State private var showEdit = false
+    @State private var editingAsset: AssetEntity? = nil
+    private let assetRepository = CoreDataAssetRepository()
 
     public init(home: HomeEntity, assets: Binding<[AssetEntity]>) {
         self.home = home
@@ -13,11 +16,29 @@ public struct AssetsListView: View {
 
     public var body: some View {
         List(assets) { asset in
-            NavigationLink(destination: AssetDetailView(asset: asset)) {
+            NavigationLink(destination: AssetDetailView(home: home, asset: asset)) {
                 Text(asset.name)
+            }
+            .swipeActions {
+                Button("Edit") {
+                    editingAsset = asset
+                    showEdit = true
+                }.tint(.blue)
             }
         }
         .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
+        .navigationDestination(isPresented: $showEdit) {
+            EditAssetView(home: home, asset: editingAsset) { newAsset in
+                Task {
+                    if let _ = editingAsset {
+                        try? await assetRepository.update(asset: newAsset)
+                        if let idx = assets.firstIndex(where: { $0.id == newAsset.id }) {
+                            assets[idx] = newAsset
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 #endif

--- a/HomeUpkeepPal/Features/Assets/EditAssetView.swift
+++ b/HomeUpkeepPal/Features/Assets/EditAssetView.swift
@@ -18,12 +18,14 @@ public struct EditAssetView: View {
 
     private let home: HomeEntity
     private let onSave: (AssetEntity) -> Void
+    private let existingAsset: AssetEntity?
 
     public init(home: HomeEntity,
                 asset: AssetEntity? = nil,
                 onSave: @escaping (AssetEntity) -> Void = { _ in }) {
         self.home = home
         self.onSave = onSave
+        self.existingAsset = asset
         _name = State(initialValue: asset?.name ?? "")
         _category = State(initialValue: asset?.category ?? .other)
         _location = State(initialValue: asset?.location ?? "")
@@ -68,6 +70,7 @@ public struct EditAssetView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
                     let asset = AssetEntity(
+                        id: existingAsset?.id ?? UUID(),
                         homeID: home.id,
                         name: name,
                         category: category,
@@ -77,7 +80,9 @@ public struct EditAssetView: View {
                         purchaseDate: hasPurchaseDate ? purchaseDate : nil,
                         warrantyExpiry: hasWarrantyExpiry ? warrantyExpiry : nil,
                         notes: notes.isEmpty ? nil : notes,
-                        photoFileNames: photosText.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+                        photoFileNames: photosText.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) },
+                        createdAt: existingAsset?.createdAt ?? Date(),
+                        updatedAt: Date()
                     )
                     onSave(asset)
                     dismiss()

--- a/HomeUpkeepPal/Features/Homes/EditHomeView.swift
+++ b/HomeUpkeepPal/Features/Homes/EditHomeView.swift
@@ -9,9 +9,11 @@ public struct EditHomeView: View {
     @State private var notes: String
 
     private let onSave: (HomeEntity) -> Void
+    private let existingHome: HomeEntity?
 
     public init(home: HomeEntity? = nil, onSave: @escaping (HomeEntity) -> Void = { _ in }) {
         self.onSave = onSave
+        self.existingHome = home
         _name = State(initialValue: home?.name ?? "")
         _address = State(initialValue: home?.address ?? "")
         _notes = State(initialValue: home?.notes ?? "")
@@ -30,9 +32,12 @@ public struct EditHomeView: View {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
                     let home = HomeEntity(
+                        id: existingHome?.id ?? UUID(),
                         name: name,
                         address: address.isEmpty ? nil : address,
-                        notes: notes.isEmpty ? nil : notes
+                        notes: notes.isEmpty ? nil : notes,
+                        createdAt: existingHome?.createdAt ?? Date(),
+                        updatedAt: Date()
                     )
                     onSave(home)
                     dismiss()

--- a/HomeUpkeepPal/Features/Homes/HomesListView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomesListView.swift
@@ -7,6 +7,7 @@ public struct HomesListView: View {
     public init() {}
     @State private var homes: [HomeEntity] = []
     @State private var showEditHome = false
+    @State private var editingHome: HomeEntity? = nil
 
     public var body: some View {
         NavigationStack {
@@ -14,19 +15,30 @@ public struct HomesListView: View {
                 NavigationLink(destination: HomeDashboardView(home: home)) {
                     Text(home.name)
                 }
+                .swipeActions {
+                    Button("Edit") {
+                        editingHome = home
+                        showEditHome = true
+                    }.tint(.blue)
+                }
             }
             .navigationTitle("Homes")
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: {
+                        editingHome = nil
                         showEditHome = true
                     }) { Image(systemName: "plus") }
                 }
             }
             .navigationDestination(isPresented: $showEditHome) {
-                EditHomeView { newHome in
+                EditHomeView(home: editingHome) { newHome in
                     Task {
-                        try? await homeRepository.add(home: newHome)
+                        if editingHome != nil {
+                            try? await homeRepository.update(home: newHome)
+                        } else {
+                            try? await homeRepository.add(home: newHome)
+                        }
                         homes = (try? await homeRepository.fetchHomes()) ?? homes
                     }
                 }

--- a/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
+++ b/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
@@ -16,6 +16,7 @@ public struct EditTaskView: View {
     private let asset: AssetEntity?
     private let assetRepository = CoreDataAssetRepository()
     private let onSave: (TaskEntity) -> Void
+    private let existingTask: TaskEntity?
 
     public init(home: HomeEntity,
                 asset: AssetEntity? = nil,
@@ -24,6 +25,7 @@ public struct EditTaskView: View {
         self.home = home
         self.asset = asset
         self.onSave = onSave
+        self.existingTask = task
         _title = State(initialValue: task?.title ?? "")
         _frequencyDays = State(initialValue: task?.frequencyDays ?? 1)
         _lastDoneAt = State(initialValue: task?.lastDoneAt ?? Date())
@@ -58,8 +60,9 @@ public struct EditTaskView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") {
-                    let nextDue = Calendar.current.date(byAdding: .day, value: frequencyDays, to: lastDoneAt) ?? Date()
+                    let nextDue = ComputeNextDueUseCase().execute(lastDone: lastDoneAt, frequencyDays: frequencyDays)
                     let task = TaskEntity(
+                        id: existingTask?.id ?? UUID(),
                         homeID: home.id,
                         assetID: selectedAssetID,
                         title: title,
@@ -67,7 +70,9 @@ public struct EditTaskView: View {
                         frequencyDays: frequencyDays,
                         lastDoneAt: lastDoneAt,
                         nextDueAt: nextDue,
-                        isArchived: isArchived
+                        isArchived: isArchived,
+                        createdAt: existingTask?.createdAt ?? Date(),
+                        updatedAt: Date()
                     )
                     onSave(task)
                     dismiss()

--- a/HomeUpkeepPal/Features/Tasks/TaskRowView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TaskRowView.swift
@@ -10,9 +10,15 @@ public struct TaskRowView: View {
     public var body: some View {
         VStack(alignment: .leading) {
             Text(task.title)
-            Text(task.nextDueAt, style: .date)
-                .font(.caption)
-                .foregroundColor(.secondary)
+            if task.isArchived, let done = task.lastDoneAt {
+                Text("Completed \(done, style: .date)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text(task.nextDueAt, style: .date)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
         }
     }
 }

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -5,17 +5,77 @@ import SwiftUI
 public struct TasksListView: View {
     public let home: HomeEntity
     @Binding private var tasks: [TaskEntity]
+    @State private var showCompleted = false
+    private let taskRepository = CoreDataTaskRepository()
+    private var computeNextDue = ComputeNextDueUseCase()
 
     public init(home: HomeEntity, tasks: Binding<[TaskEntity]>) {
         self.home = home
         _tasks = tasks
     }
 
+    private var filteredTasks: [TaskEntity] {
+        tasks.filter { showCompleted ? $0.isArchived : !$0.isArchived }
+    }
+
     public var body: some View {
-        List(tasks) { task in
-            TaskRowView(task: task)
+        List {
+            ForEach(filteredTasks) { task in
+                HStack {
+                    Button(action: { toggle(task) }) {
+                        Image(systemName: task.isArchived ? "checkmark.circle" : "circle")
+                    }
+                    NavigationLink(destination: EditTaskView(home: home, task: task) { updated in
+                        Task {
+                            try? await taskRepository.update(task: updated)
+                            if let idx = tasks.firstIndex(where: { $0.id == updated.id }) {
+                                tasks[idx] = updated
+                            }
+                        }
+                    }) {
+                        TaskRowView(task: task)
+                    }
+                }
+            }
         }
-        .overlay(tasks.isEmpty ? EmptyStateView(message: "No tasks yet") : nil)
+        .overlay(filteredTasks.isEmpty ? EmptyStateView(message: showCompleted ? "No completed tasks" : "No tasks yet") : nil)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(showCompleted ? "Hide Completed" : "Show Completed") { showCompleted.toggle() }
+            }
+        }
+    }
+
+    private func toggle(_ task: TaskEntity) {
+        Task {
+            guard let idx = tasks.firstIndex(where: { $0.id == task.id }) else { return }
+            var updated = task
+            if task.isArchived {
+                updated.isArchived = false
+                updated.lastDoneAt = nil
+                updated.updatedAt = Date()
+                try? await taskRepository.update(task: updated)
+                tasks[idx] = updated
+            } else {
+                let now = Date()
+                updated.isArchived = true
+                updated.lastDoneAt = now
+                updated.updatedAt = now
+                try? await taskRepository.update(task: updated)
+                tasks[idx] = updated
+
+                let nextDue = computeNextDue.execute(lastDone: now, frequencyDays: task.frequencyDays)
+                let newTask = TaskEntity(homeID: task.homeID,
+                                         assetID: task.assetID,
+                                         title: task.title,
+                                         notes: task.notes,
+                                         frequencyDays: task.frequencyDays,
+                                         lastDoneAt: nil,
+                                         nextDueAt: nextDue)
+                try? await taskRepository.add(task: newTask)
+                tasks.append(newTask)
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
## Summary
- Allow homes, assets and tasks to be edited with pre-filled forms
- Add swipe actions and detail buttons to edit assets and homes
- Let tasks be marked complete with a radio button, generate the next recurring task, and toggle viewing completed items

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e560d6ce08327a68e17cb4566d180