### PR TITLE
Fix task toggle navigation and add settings/share links

### DIFF
--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -31,7 +31,15 @@ public struct HomeDashboardView: View {
         }
         .navigationTitle(selection == .tasks ? "Tasks" : "Assets")
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItem(placement: .navigationBarLeading) {
+                NavigationLink(destination: SettingsView()) {
+                    Image(systemName: "gearshape")
+                }
+            }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                NavigationLink(destination: ShareStatusView(home: home)) {
+                    Image(systemName: "square.and.arrow.up")
+                }
                 Button(action: {
                     switch selection {
                     case .tasks: showEditTask = true

--- a/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
+++ b/HomeUpkeepPal/Features/Tasks/EditTaskView.swift
@@ -82,6 +82,10 @@ public struct EditTaskView: View {
         }
         .task {
             assets = (try? await assetRepository.fetchAssets(homeID: home.id)) ?? []
+            if let selected = selectedAssetID,
+               !assets.contains(where: { $0.id == selected }) {
+                selectedAssetID = nil
+            }
         }
     }
 }

--- a/HomeUpkeepPal/Features/Tasks/TasksListView.swift
+++ b/HomeUpkeepPal/Features/Tasks/TasksListView.swift
@@ -25,6 +25,8 @@ public struct TasksListView: View {
                     Button(action: { toggle(task) }) {
                         Image(systemName: task.isArchived ? "checkmark.circle" : "circle")
                     }
+                    .buttonStyle(.plain)
+
                     NavigationLink(destination: EditTaskView(home: home, task: task) { updated in
                         Task {
                             try? await taskRepository.update(task: updated)


### PR DESCRIPTION
## Summary
- Prevent task completion button from triggering navigation
- Add navigation links to Settings and Sharing screens
- Reset invalid asset selections when editing tasks

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e5e5cf90c832789ae1d48b61117f4