### PR TITLE
Fix navigationDestination inside lazy containers

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetDetailView.swift
@@ -14,32 +14,34 @@ public struct AssetDetailView: View {
     }
 
     public var body: some View {
-        List {
-            Section("Details") {
-                Text(asset.name)
-                Text(asset.category.rawValue.capitalized)
-                if let location = asset.location { Text(location) }
-                if let model = asset.model { Text(model) }
-                if let serial = asset.serial { Text(serial) }
-                if let purchase = asset.purchaseDate {
-                    Text("Purchased on \(purchase.formatted(date: .abbreviated, time: .omitted))")
-                }
-                if let warranty = asset.warrantyExpiry {
-                    Text("Warranty expires \(warranty.formatted(date: .abbreviated, time: .omitted))")
-                }
-            }
-            if let notes = asset.notes {
-                Section("Notes") { Text(notes) }
-            }
-            if !asset.photoFileNames.isEmpty {
-                Section("Photos") {
-                    ForEach(asset.photoFileNames, id: \.self) { name in
-                        Text(name)
+        Group {
+            List {
+                Section("Details") {
+                    Text(asset.name)
+                    Text(asset.category.rawValue.capitalized)
+                    if let location = asset.location { Text(location) }
+                    if let model = asset.model { Text(model) }
+                    if let serial = asset.serial { Text(serial) }
+                    if let purchase = asset.purchaseDate {
+                        Text("Purchased on \(purchase.formatted(date: .abbreviated, time: .omitted))")
+                    }
+                    if let warranty = asset.warrantyExpiry {
+                        Text("Warranty expires \(warranty.formatted(date: .abbreviated, time: .omitted))")
                     }
                 }
-            }
-            Section("Tasks") {
-                Text("Related tasks appear here")
+                if let notes = asset.notes {
+                    Section("Notes") { Text(notes) }
+                }
+                if !asset.photoFileNames.isEmpty {
+                    Section("Photos") {
+                        ForEach(asset.photoFileNames, id: \.self) { name in
+                            Text(name)
+                        }
+                    }
+                }
+                Section("Tasks") {
+                    Text("Related tasks appear here")
+                }
             }
         }
         .navigationTitle(asset.name)

--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -15,18 +15,20 @@ public struct AssetsListView: View {
     }
 
     public var body: some View {
-        List(assets) { asset in
-            NavigationLink(destination: AssetDetailView(home: home, asset: asset)) {
-                Text(asset.name)
+        Group {
+            List(assets) { asset in
+                NavigationLink(destination: AssetDetailView(home: home, asset: asset)) {
+                    Text(asset.name)
+                }
+                .swipeActions {
+                    Button("Edit") {
+                        editingAsset = asset
+                        showEdit = true
+                    }.tint(.blue)
+                }
             }
-            .swipeActions {
-                Button("Edit") {
-                    editingAsset = asset
-                    showEdit = true
-                }.tint(.blue)
-            }
+            .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
         }
-        .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
         .navigationDestination(isPresented: $showEdit) {
             EditAssetView(home: home, asset: editingAsset) { newAsset in
                 Task {

--- a/HomeUpkeepPal/Features/Homes/HomesListView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomesListView.swift
@@ -22,28 +22,28 @@ public struct HomesListView: View {
                     }.tint(.blue)
                 }
             }
-            .navigationTitle("Homes")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: {
-                        editingHome = nil
-                        showEditHome = true
-                    }) { Image(systemName: "plus") }
-                }
-            }
-            .navigationDestination(isPresented: $showEditHome) {
-                EditHomeView(home: editingHome) { newHome in
-                    Task {
-                        if editingHome != nil {
-                            try? await homeRepository.update(home: newHome)
-                        } else {
-                            try? await homeRepository.add(home: newHome)
-                        }
-                        homes = (try? await homeRepository.fetchHomes()) ?? homes
-                    }
-                }
-            }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)
+        }
+        .navigationTitle("Homes")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(action: {
+                    editingHome = nil
+                    showEditHome = true
+                }) { Image(systemName: "plus") }
+            }
+        }
+        .navigationDestination(isPresented: $showEditHome) {
+            EditHomeView(home: editingHome) { newHome in
+                Task {
+                    if editingHome != nil {
+                        try? await homeRepository.update(home: newHome)
+                    } else {
+                        try? await homeRepository.add(home: newHome)
+                    }
+                    homes = (try? await homeRepository.fetchHomes()) ?? homes
+                }
+            }
         }
         .task {
             homes = (try? await homeRepository.fetchHomes()) ?? []


### PR DESCRIPTION
## Summary
- Wrap asset list in `Group` and move navigationDestination out to avoid lazy container warning
- Wrap asset detail list similarly
- Attach home editing destination to NavigationStack instead of List

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e61c2a25c83278e5199123727c243