### PR TITLE
Fix navigation handling for Homes and Assets views

### DIFF
--- a/HomeUpkeepPal/Features/Assets/AssetsListView.swift
+++ b/HomeUpkeepPal/Features/Assets/AssetsListView.swift
@@ -5,42 +5,26 @@ import SwiftUI
 public struct AssetsListView: View {
     public let home: HomeEntity
     @Binding private var assets: [AssetEntity]
-    @State private var showEdit = false
-    @State private var editingAsset: AssetEntity? = nil
-    private let assetRepository = CoreDataAssetRepository()
+    private let onEdit: (AssetEntity) -> Void
 
-    public init(home: HomeEntity, assets: Binding<[AssetEntity]>) {
+    public init(home: HomeEntity, assets: Binding<[AssetEntity]>, onEdit: @escaping (AssetEntity) -> Void) {
         self.home = home
         _assets = assets
+        self.onEdit = onEdit
     }
 
     public var body: some View {
-        Group {
-            List(assets) { asset in
-                NavigationLink(destination: AssetDetailView(home: home, asset: asset)) {
-                    Text(asset.name)
-                }
-                .swipeActions {
-                    Button("Edit") {
-                        editingAsset = asset
-                        showEdit = true
-                    }.tint(.blue)
-                }
+        List(assets) { asset in
+            NavigationLink(destination: AssetDetailView(home: home, asset: asset)) {
+                Text(asset.name)
             }
-            .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
-        }
-        .navigationDestination(isPresented: $showEdit) {
-            EditAssetView(home: home, asset: editingAsset) { newAsset in
-                Task {
-                    if let _ = editingAsset {
-                        try? await assetRepository.update(asset: newAsset)
-                        if let idx = assets.firstIndex(where: { $0.id == newAsset.id }) {
-                            assets[idx] = newAsset
-                        }
-                    }
-                }
+            .swipeActions {
+                Button("Edit") {
+                    onEdit(asset)
+                }.tint(.blue)
             }
         }
+        .overlay(assets.isEmpty ? EmptyStateView(message: "No assets yet") : nil)
     }
 }
 #endif

--- a/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomeDashboardView.swift
@@ -9,6 +9,7 @@ public struct HomeDashboardView: View {
     @State private var selection: Tab = .tasks
     @State private var showEditTask = false
     @State private var showEditAsset = false
+    @State private var editingAsset: AssetEntity? = nil
     @State private var tasks: [TaskEntity] = []
     @State private var assets: [AssetEntity] = []
 
@@ -20,14 +21,44 @@ public struct HomeDashboardView: View {
     public init(home: HomeEntity) { self.home = home }
 
     public var body: some View {
-        TabView(selection: $selection) {
-            TasksListView(home: home, tasks: $tasks)
-                .tabItem { Label("Tasks", systemImage: "checklist") }
-                .tag(Tab.tasks)
+        ZStack {
+            TabView(selection: $selection) {
+                TasksListView(home: home, tasks: $tasks)
+                    .tabItem { Label("Tasks", systemImage: "checklist") }
+                    .tag(Tab.tasks)
 
-            AssetsListView(home: home, assets: $assets)
-                .tabItem { Label("Assets", systemImage: "cube") }
-                .tag(Tab.assets)
+                AssetsListView(home: home, assets: $assets) { asset in
+                    editingAsset = asset
+                    showEditAsset = true
+                }
+                    .tabItem { Label("Assets", systemImage: "cube") }
+                    .tag(Tab.assets)
+            }
+
+            NavigationLink(isActive: $showEditTask) {
+                EditTaskView(home: home) { task in
+                    Task {
+                        try? await taskRepository.add(task: task)
+                        tasks = (try? await taskRepository.fetchTasks(homeID: home.id)) ?? tasks
+                    }
+                }
+            } label: { EmptyView() }
+
+            NavigationLink(isActive: $showEditAsset) {
+                EditAssetView(home: home, asset: editingAsset) { asset in
+                    Task {
+                        if let _ = editingAsset {
+                            try? await assetRepository.update(asset: asset)
+                            if let idx = assets.firstIndex(where: { $0.id == asset.id }) {
+                                assets[idx] = asset
+                            }
+                        } else {
+                            try? await assetRepository.add(asset: asset)
+                            assets = (try? await assetRepository.fetchAssets(homeID: home.id)) ?? assets
+                        }
+                    }
+                }
+            } label: { EmptyView() }
         }
         .navigationTitle(selection == .tasks ? "Tasks" : "Assets")
         .toolbar {
@@ -42,27 +73,14 @@ public struct HomeDashboardView: View {
                 }
                 Button(action: {
                     switch selection {
-                    case .tasks: showEditTask = true
-                    case .assets: showEditAsset = true
+                    case .tasks:
+                        showEditTask = true
+                    case .assets:
+                        editingAsset = nil
+                        showEditAsset = true
                     }
                 }) {
                     Image(systemName: "plus")
-                }
-            }
-        }
-        .navigationDestination(isPresented: $showEditTask) {
-            EditTaskView(home: home) { task in
-                Task {
-                    try? await taskRepository.add(task: task)
-                    tasks = (try? await taskRepository.fetchTasks(homeID: home.id)) ?? tasks
-                }
-            }
-        }
-        .navigationDestination(isPresented: $showEditAsset) {
-            EditAssetView(home: home) { asset in
-                Task {
-                    try? await assetRepository.add(asset: asset)
-                    assets = (try? await assetRepository.fetchAssets(homeID: home.id)) ?? assets
                 }
             }
         }

--- a/HomeUpkeepPal/Features/Homes/HomesListView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomesListView.swift
@@ -23,6 +23,19 @@ public struct HomesListView: View {
                 }
             }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)
+
+            NavigationLink(isActive: $showEditHome) {
+                EditHomeView(home: editingHome) { newHome in
+                    Task {
+                        if editingHome != nil {
+                            try? await homeRepository.update(home: newHome)
+                        } else {
+                            try? await homeRepository.add(home: newHome)
+                        }
+                        homes = (try? await homeRepository.fetchHomes()) ?? homes
+                    }
+                }
+            } label: { EmptyView() }
         }
         .navigationTitle("Homes")
         .toolbar {
@@ -31,18 +44,6 @@ public struct HomesListView: View {
                     editingHome = nil
                     showEditHome = true
                 }) { Image(systemName: "plus") }
-            }
-        }
-        .navigationDestination(isPresented: $showEditHome) {
-            EditHomeView(home: editingHome) { newHome in
-                Task {
-                    if editingHome != nil {
-                        try? await homeRepository.update(home: newHome)
-                    } else {
-                        try? await homeRepository.add(home: newHome)
-                    }
-                    homes = (try? await homeRepository.fetchHomes()) ?? homes
-                }
             }
         }
         .task {


### PR DESCRIPTION
## Summary
- Replace misplaced navigation destinations with hidden NavigationLinks so navigation bars render and warnings disappear
- Move asset edit navigation out of lazy List via closure handled in HomeDashboardView

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e63cb38f48327865c19568afc67ef