### PR TITLE
Fix missing Homes header and add button

### DIFF
--- a/HomeUpkeepPal/Features/Homes/HomesListView.swift
+++ b/HomeUpkeepPal/Features/Homes/HomesListView.swift
@@ -23,6 +23,15 @@ public struct HomesListView: View {
                 }
             }
             .overlay(homes.isEmpty ? EmptyStateView(message: "Create your first Home") : nil)
+            .navigationTitle("Homes")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        editingHome = nil
+                        showEditHome = true
+                    }) { Image(systemName: "plus") }
+                }
+            }
 
             NavigationLink(isActive: $showEditHome) {
                 EditHomeView(home: editingHome) { newHome in
@@ -36,15 +45,6 @@ public struct HomesListView: View {
                     }
                 }
             } label: { EmptyView() }
-        }
-        .navigationTitle("Homes")
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button(action: {
-                    editingHome = nil
-                    showEditHome = true
-                }) { Image(systemName: "plus") }
-            }
         }
         .task {
             homes = (try? await homeRepository.fetchHomes()) ?? []


### PR DESCRIPTION
## Summary
- Ensure Homes list has visible "Homes" navigation title
- Restore toolbar plus button for creating new homes

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689e6819e0608327b86396a804d3638a